### PR TITLE
writeページで保存を押した際の改行と、段落の変更の処理

### DIFF
--- a/dokkai-craft/src/app/write/page.tsx
+++ b/dokkai-craft/src/app/write/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 import styles from "./page.module.css"
+import { parseContent } from "@/lib/utils"
+
 
 export default function WritePage() {
   const [title, setTitle] = useState("")
@@ -85,18 +87,26 @@ export default function WritePage() {
     setAiSuggestions([])
   }
 
-  // 作品を保存
-  const saveNovel = () => {
-    if (!title) {
-      alert("タイトルが入力されていません: 作品を保存するには、タイトルを入力してください。")
-      return
+    const saveNovel = () => {
+        if (!title) {
+            alert("タイトルが入力されていません: 作品を保存するには、タイトルを入力してください。")
+            return
+        }
+
+        const parsedContent = parseContent(content)
+
+        // 実際の実装ではバックエンドにデータを送信
+        console.log("送信データ", {
+            title,
+            genre,
+            content: parsedContent
+        })
+
+        alert("作品が保存されました: 下書きとして保存しました。")
     }
 
-    // 実際の実装ではバックエンドにデータを送信
-    alert("作品が保存されました: 下書きとして保存しました。")
-  }
 
-  return (
+    return (
     <div className={styles.container}>
       <div className={styles.editorContainer}>
         <div style={{ flex: 1 }}>

--- a/dokkai-craft/src/lib/utils.ts
+++ b/dokkai-craft/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// --- 改行&段落の変更をして、バックエンドに送る～ ---
+export type ParsedLine = {
+  type: "paragraph" | "line",
+  text: string
+}
+
+export const parseContent = (raw: string): ParsedLine[] => {
+  return raw.split("\n").map(line => {
+    const trimmed = line.trim()
+    if (!trimmed) return { type: "line", text: "" } // 空行もlineとして保持
+    return line.startsWith("　")
+        ? { type: "paragraph", text: trimmed }
+        : { type: "line", text: trimmed }
+  })
+}


### PR DESCRIPTION
全角スペースが最初にある場合、paragraphとして段落の変更に。無ければlineとして改行に

## 🖇 関連Issue

https://github.com/U-22-contest/frontend/issues/23#issue-3131822754

##  🎂 やったこと

writeページで、保存を押した際に、小説の内容に最初に全角スペースがあればparagraphとして段落の変更として処理をする。
最初に全角スペースのない場合、改行としてlineで
![image](https://github.com/user-attachments/assets/98ffdb58-45fe-4c81-b167-b747e4f3df76)

<!-- 実装内容を書く -->

writeページで、保存を押した際に、小説の内容に最初に全角スペースがあればparagraphとして段落の変更として処理をする。
最初に全角スペースのない場合、改行としてlineで

## ⛔ やってないこと

いったん形を決めて、ブラウザのコンソールに表示することしかしていないので、バックエンドに送る形に後々変更する必要あり

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
