### PR TITLE
ユーザー登録で登録する情報をいったんコンソールに表示

### DIFF
--- a/dokkai-craft/src/app/api/register/route.ts
+++ b/dokkai-craft/src/app/api/register/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+
+type NewUser = {
+    username: string
+    email: string
+    password: string
+}
+
+export async function POST(request: Request) {
+    const body = (await request.json()) as NewUser
+
+
+    if (!body.username || !body.email || !body.password) {
+        return NextResponse.json({ message: "missing field" }, { status: 400 })
+    }
+
+    // ────────────────────────────────
+    // ここで DB 保存やパスワードハッシュ化を行う想定
+    // ────────────────────────────────
+    console.log("🆕 user registered:", body)
+
+    return NextResponse.json({ message: "ok" }, { status: 200 })
+}

--- a/dokkai-craft/src/app/register/page.tsx
+++ b/dokkai-craft/src/app/register/page.tsx
@@ -7,235 +7,257 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 
 export default function RegisterPage() {
-  const router = useRouter()
-  const [isLoading, setIsLoading] = useState(false)
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
-  })
+    const router = useRouter()
+    const [isLoading, setIsLoading] = useState(false)
+    const [formData, setFormData] = useState({
+        username: "",
+        email: "",
+        password: "",
+        confirmPassword: "",
+    })
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target
-    setFormData((prev) => ({ ...prev, [name]: value }))
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (formData.password !== formData.confirmPassword) {
-      alert("パスワードが一致しません: 確認用パスワードが一致していることを確認してください")
-      return
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target
+        setFormData((prev) => ({ ...prev, [name]: value }))
     }
 
-    setIsLoading(true)
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
 
-    try {
-      // 実際の実装ではバックエンドAPIを呼び出して登録処理
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+        if (formData.password !== formData.confirmPassword) {
+            alert(
+                "パスワードが一致しません: 確認用パスワードが一致していることを確認してください"
+            )
+            return
+        }
 
-      alert("登録が完了しました: ログインしてサービスをご利用ください")
-      router.push("/login")
-    } catch {
-      alert("エラーが発生しました: 後でもう一度お試しください")
-    } finally {
-      setIsLoading(false)
+        setIsLoading(true)
+
+        // バックエンドに送るデータ
+        const payload = {
+            username: formData.username.trim(),
+            email: formData.email.trim(),
+            password: formData.password,
+        }
+
+        // いったんコンソールに表示
+        console.log("📤 register payload", payload)
+
+        try {
+            const res = await fetch("/api/register", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            })
+
+            if (!res.ok) throw new Error(`Failed with status ${res.status}`)
+
+            alert("登録が完了しました: ログインしてサービスをご利用ください")
+            router.push("/login")
+        } catch (err) {
+            console.error(err)
+            alert("エラーが発生しました: 後でもう一度お試しください")
+        } finally {
+            setIsLoading(false)
+        }
     }
-  }
 
-  return (
-    <div
-      style={{
-        display: "flex",
-        height: "100vh",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "0 1rem",
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: "var(--bg-color)",
-          borderRadius: "0.5rem",
-          border: "1px solid var(--border-color)",
-          boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-          width: "100%",
-          maxWidth: "24rem",
-          margin: "0 auto",
-          overflow: "hidden",
-        }}
-      >
-        <div style={{ padding: "1.25rem 1.5rem", borderBottom: "1px solid var(--border-color)" }}>
-          <h1 style={{ fontSize: "1.5rem", fontWeight: "bold" }}>アカウント登録</h1>
-          <p style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>新しいアカウントを作成して始めましょう</p>
-        </div>
-        <form onSubmit={handleSubmit}>
-          <div style={{ padding: "1.5rem" }}>
-            <div style={{ marginBottom: "1rem" }}>
-              <label
-                htmlFor="name"
-                style={{
-                  display: "block",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  marginBottom: "0.5rem",
-                }}
-              >
-                ユーザー名
-              </label>
-              <input
-                id="name"
-                name="name"
-                placeholder="ユーザー名"
-                required
-                value={formData.name}
-                onChange={handleChange}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem 0.75rem",
-                  borderRadius: "0.375rem",
-                  border: "1px solid var(--border-color)",
-                  backgroundColor: "var(--bg-color)",
-                  color: "var(--text-color)",
-                  fontSize: "0.875rem",
-                }}
-              />
-            </div>
-            <div style={{ marginBottom: "1rem" }}>
-              <label
-                htmlFor="email"
-                style={{
-                  display: "block",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  marginBottom: "0.5rem",
-                }}
-              >
-                メールアドレス
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                placeholder="example@example.com"
-                required
-                value={formData.email}
-                onChange={handleChange}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem 0.75rem",
-                  borderRadius: "0.375rem",
-                  border: "1px solid var(--border-color)",
-                  backgroundColor: "var(--bg-color)",
-                  color: "var(--text-color)",
-                  fontSize: "0.875rem",
-                }}
-              />
-            </div>
-            <div style={{ marginBottom: "1rem" }}>
-              <label
-                htmlFor="password"
-                style={{
-                  display: "block",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  marginBottom: "0.5rem",
-                }}
-              >
-                パスワード
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                required
-                value={formData.password}
-                onChange={handleChange}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem 0.75rem",
-                  borderRadius: "0.375rem",
-                  border: "1px solid var(--border-color)",
-                  backgroundColor: "var(--bg-color)",
-                  color: "var(--text-color)",
-                  fontSize: "0.875rem",
-                }}
-              />
-            </div>
-            <div style={{ marginBottom: "1.5rem" }}>
-              <label
-                htmlFor="confirmPassword"
-                style={{
-                  display: "block",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  marginBottom: "0.5rem",
-                }}
-              >
-                パスワード（確認）
-              </label>
-              <input
-                id="confirmPassword"
-                name="confirmPassword"
-                type="password"
-                required
-                value={formData.confirmPassword}
-                onChange={handleChange}
-                style={{
-                  width: "100%",
-                  padding: "0.5rem 0.75rem",
-                  borderRadius: "0.375rem",
-                  border: "1px solid var(--border-color)",
-                  backgroundColor: "var(--bg-color)",
-                  color: "var(--text-color)",
-                  fontSize: "0.875rem",
-                }}
-              />
-            </div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              style={{
-                width: "100%",
-                display: "flex",
-                justifyContent: "center",
-                padding: "0.5rem 1rem",
-                borderRadius: "0.375rem",
-                fontSize: "0.875rem",
-                fontWeight: 500,
-                backgroundColor: "var(--primary-color)",
-                color: "var(--primary-foreground)",
-                border: "none",
-                cursor: isLoading ? "not-allowed" : "pointer",
-                opacity: isLoading ? 0.5 : 1,
-              }}
-            >
-              {isLoading ? "登録中..." : "登録する"}
-            </button>
-          </div>
-        </form>
+    return (
         <div
-          style={{
-            padding: "1rem 1.5rem",
-            borderTop: "1px solid var(--border-color)",
-            textAlign: "center",
-          }}
+            style={{
+                display: "flex",
+                height: "100vh",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "0 1rem",
+            }}
         >
-          <p style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>
-            すでにアカウントをお持ちですか？{" "}
-            <Link
-              href="/login"
-              style={{
-                color: "var(--primary-color)",
-                textDecoration: "none",
-              }}
+            <div
+                style={{
+                    backgroundColor: "var(--bg-color)",
+                    borderRadius: "0.5rem",
+                    border: "1px solid var(--border-color)",
+                    boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                    width: "100%",
+                    maxWidth: "24rem",
+                    margin: "0 auto",
+                    overflow: "hidden",
+                }}
             >
-              ログイン
-            </Link>
-          </p>
+                <div
+                    style={{ padding: "1.25rem 1.5rem", borderBottom: "1px solid var(--border-color)" }}
+                >
+                    <h1 style={{ fontSize: "1.5rem", fontWeight: "bold" }}>アカウント登録</h1>
+                    <p style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>
+                        新しいアカウントを作成して始めましょう
+                    </p>
+                </div>
+                <form onSubmit={handleSubmit}>
+                    <div style={{ padding: "1.5rem" }}>
+                        <div style={{ marginBottom: "1rem" }}>
+                            <label
+                                htmlFor="name"
+                                style={{
+                                    display: "block",
+                                    fontSize: "0.875rem",
+                                    fontWeight: 500,
+                                    marginBottom: "0.5rem",
+                                }}
+                            >
+                                ユーザー名
+                            </label>
+                            <input
+                                id="username"
+                                name="username"
+                                placeholder="ユーザー名"
+                                required
+                                value={formData.username}
+                                onChange={handleChange}
+                                style={{
+                                    width: "100%",
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "0.375rem",
+                                    border: "1px solid var(--border-color)",
+                                    backgroundColor: "var(--bg-color)",
+                                    color: "var(--text-color)",
+                                    fontSize: "0.875rem",
+                                }}
+                            />
+                        </div>
+                        <div style={{ marginBottom: "1rem" }}>
+                            <label
+                                htmlFor="email"
+                                style={{
+                                    display: "block",
+                                    fontSize: "0.875rem",
+                                    fontWeight: 500,
+                                    marginBottom: "0.5rem",
+                                }}
+                            >
+                                メールアドレス
+                            </label>
+                            <input
+                                id="email"
+                                name="email"
+                                type="email"
+                                placeholder="example@example.com"
+                                required
+                                value={formData.email}
+                                onChange={handleChange}
+                                style={{
+                                    width: "100%",
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "0.375rem",
+                                    border: "1px solid var(--border-color)",
+                                    backgroundColor: "var(--bg-color)",
+                                    color: "var(--text-color)",
+                                    fontSize: "0.875rem",
+                                }}
+                            />
+                        </div>
+                        <div style={{ marginBottom: "1rem" }}>
+                            <label
+                                htmlFor="password"
+                                style={{
+                                    display: "block",
+                                    fontSize: "0.875rem",
+                                    fontWeight: 500,
+                                    marginBottom: "0.5rem",
+                                }}
+                            >
+                                パスワード
+                            </label>
+                            <input
+                                id="password"
+                                name="password"
+                                type="password"
+                                required
+                                value={formData.password}
+                                onChange={handleChange}
+                                style={{
+                                    width: "100%",
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "0.375rem",
+                                    border: "1px solid var(--border-color)",
+                                    backgroundColor: "var(--bg-color)",
+                                    color: "var(--text-color)",
+                                    fontSize: "0.875rem",
+                                }}
+                            />
+                        </div>
+                        <div style={{ marginBottom: "1.5rem" }}>
+                            <label
+                                htmlFor="confirmPassword"
+                                style={{
+                                    display: "block",
+                                    fontSize: "0.875rem",
+                                    fontWeight: 500,
+                                    marginBottom: "0.5rem",
+                                }}
+                            >
+                                パスワード（確認）
+                            </label>
+                            <input
+                                id="confirmPassword"
+                                name="confirmPassword"
+                                type="password"
+                                required
+                                value={formData.confirmPassword}
+                                onChange={handleChange}
+                                style={{
+                                    width: "100%",
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "0.375rem",
+                                    border: "1px solid var(--border-color)",
+                                    backgroundColor: "var(--bg-color)",
+                                    color: "var(--text-color)",
+                                    fontSize: "0.875rem",
+                                }}
+                            />
+                        </div>
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            style={{
+                                width: "100%",
+                                display: "flex",
+                                justifyContent: "center",
+                                padding: "0.5rem 1rem",
+                                borderRadius: "0.375rem",
+                                fontSize: "0.875rem",
+                                fontWeight: 500,
+                                backgroundColor: "var(--primary-color)",
+                                color: "var(--primary-foreground)",
+                                border: "none",
+                                cursor: isLoading ? "not-allowed" : "pointer",
+                                opacity: isLoading ? 0.5 : 1,
+                            }}
+                        >
+                            {isLoading ? "登録中..." : "登録する"}
+                        </button>
+                    </div>
+                </form>
+                <div
+                    style={{
+                        padding: "1rem 1.5rem",
+                        borderTop: "1px solid var(--border-color)",
+                        textAlign: "center",
+                    }}
+                >
+                    <p style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>
+                        すでにアカウントをお持ちですか？{" "}
+                        <Link
+                            href="/login"
+                            style={{
+                                color: "var(--primary-color)",
+                                textDecoration: "none",
+                            }}
+                        >
+                            ログイン
+                        </Link>
+                    </p>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  )
+    )
 }


### PR DESCRIPTION
## 🖇 関連Issue

<!-- GitHub Issueのリンクを記入してください -->

##  🎂 やったこと

registerのユーザー登録で登録する情報をいったんコンソールに表示
今は username , email , password でやってるけど変更の可能性有り
![image](https://github.com/user-attachments/assets/221ea214-7f74-42df-98b4-8905f474ff1f)


## ⛔ やってないこと

実際にbackendにデータを送ってユーザー登録をする

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
